### PR TITLE
challenge: feat/initializing tmp stress + fix

### DIFF
--- a/violence/agents.py
+++ b/violence/agents.py
@@ -82,12 +82,18 @@ class Person(Agent):
         # Before updating stress, check whether conditions have changed
         self.step_change()
 
+        # initializing tmp variable, for later settings
+        if self.stress == 0:
+            tmp = self.gender_stress
+        else:
+            tmp *= (1 + self.stress)
+
         # Update stress based on gender, wage level, hours at home, family size and history of violence
         # Check new table of influences at README.md
         # Wage influences neighborhood_quality and house_size
         # Gender
         # We fixed gender stress for females in .2
-        tmp = self.model.gender_stress if self.gender == 'male' else .2
+        tmp += self.model.gender_stress if self.gender == 'male' else .2
         # Salary
         tmp += (1 - self.wage) * HIGH
         # Neighborhood quality

--- a/violence/generalization_aps.py
+++ b/violence/generalization_aps.py
@@ -30,12 +30,11 @@ def main(metro='BRASILIA', iterates=2000, steps=10):
         df_attack = pd.DataFrame.from_dict(attacked, orient='index', columns=['attacked'])
         df_denounce = pd.DataFrame.from_dict(denounced, orient='index', columns=['denounce'])
         df_females = pd.DataFrame.from_dict(females, orient='index', columns=['females'])
-        df = pd.merge(df_attack, df_denounce, right_index=True, left_index=True)
-        df = df.merge(df_females, right_index=True, left_index=True)
+        df = pd.concat([df_attack, df_denounce, df_females], axis=1).fillna(0)
         df.loc[:, 'Attacks per female'] = df.loc[:, 'attacked'] / df.loc[:, 'females'] * home.model_scale
         df.loc[:, 'Denounces per female'] = df.loc[:, 'denounce'] / df.loc[:, 'females'] * home.model_scale
         df = df.reset_index()
-        df.loc[:, 'run'] = each
+        df['run'] = each
         data = data.append(df)
     data = data.groupby('index').agg('mean')
     data = data.reset_index()

--- a/violence/input/generator.py
+++ b/violence/input/generator.py
@@ -60,6 +60,7 @@ def generate_people(params, ppl, col):
     people = people[['AREAP', 'gender', 'age']]
     # for i, idx in enumerate(indexes):
     #     people.loc[i] = ppl.loc[idx]
+    people['gender'] = people['gender'].astype(str)
     people.loc[people['gender'] == 1, 'gender'] = 'female'
     people.loc[people['gender'] == 2, 'gender'] = 'male'
     # people.AREAP = people.AREAP.astype(int)

--- a/violence/model.py
+++ b/violence/model.py
@@ -189,7 +189,8 @@ class Home(Model):
             if isinstance(agent, Family):
                 count += agent.context_stress
                 size += 1
-        return count / size
+        if size:
+            return count / size
 
     def run_model(self, step_count=200):
 


### PR DESCRIPTION
## Alterações Realizadas:
- Inicialização do valor de tmp, baseada na condição proposta no desafio
- na geração de dataframe, utilização de concat, a fim de se evitar múltiplos merges
- aparentemente, na versão mais recente do pandas, surgiu uma necessidade de tipagem em alteração de frames (provavelmente um bug), então ajustei isso na troca de valores de gender de um número para uma string (1 -> 'female')
- esta foi detalhe, mas para evitar bugs, fiz uma checagem typesafe em count_stress, para evitar divisão por zero

## Sugestões:
- O código já está em um nível de desenvolvimento bastante avançado, então não seria ideal realizar refatorações densas de boas práticas por agr, mas futuramente cabe uma aplicação de princípios de legibilidade, como SOLID. Principalmente nos princípios de singularidade e inversão de dependências, enquanto que não vejo necessidade de aplicação do princípio de Liskov, tendo em vista que não encontrei hierarquia de classes
- Acredito ser válida revisão da nomenclatura de algumas variáveis, além de existirem algumas declaradas e não utilizadas (em trechos pontuais do código)
- No readme, acredito também ser válida declaração das versões de dependências utilizadas